### PR TITLE
DisableUpload now hardcoded as true and IsUploadAllowed as false

### DIFF
--- a/ShareX.UploadersLib/BaseUploaders/Uploader.cs
+++ b/ShareX.UploadersLib/BaseUploaders/Uploader.cs
@@ -393,6 +393,9 @@ namespace ShareX.UploadersLib
 
         protected bool TransferData(Stream dataStream, Stream requestStream, long dataPosition = 0, long dataLength = -1)
         {
+            return false;
+
+            /*
             if (dataPosition >= dataStream.Length)
             {
                 return true;
@@ -428,6 +431,7 @@ namespace ShareX.UploadersLib
             }
 
             return !StopUploadRequested;
+            */
         }
 
         private string ProcessError(Exception e, string requestURL)
@@ -509,7 +513,7 @@ namespace ShareX.UploadersLib
         {
             LastResponseInfo = null;
 
-            HttpWebRequest request = RequestHelpers.CreateWebRequest(method, url, headers, cookies, contentType, contentLength);
+            HttpWebRequest request = RequestHelpers.CreateWebRequest(method, null /* url */, headers, cookies, contentType, contentLength);
             currentWebRequest = request;
             return request;
         }
@@ -559,6 +563,7 @@ namespace ShareX.UploadersLib
         protected string GetAuthorizationURL(string requestTokenURL, string authorizeURL, OAuthInfo authInfo,
             Dictionary<string, string> customParameters = null, HttpMethod httpMethod = HttpMethod.GET)
         {
+            /*
             string url = OAuthManager.GenerateQuery(requestTokenURL, customParameters, httpMethod, authInfo);
 
             string response = SendRequest(httpMethod, url);
@@ -567,6 +572,8 @@ namespace ShareX.UploadersLib
             {
                 return OAuthManager.GetAuthorizationURL(response, authInfo, authorizeURL);
             }
+
+            */
 
             return null;
         }
@@ -578,6 +585,7 @@ namespace ShareX.UploadersLib
 
         protected NameValueCollection GetAccessTokenEx(string accessTokenURL, OAuthInfo authInfo, HttpMethod httpMethod = HttpMethod.GET)
         {
+            /*
             if (string.IsNullOrEmpty(authInfo.AuthToken) || string.IsNullOrEmpty(authInfo.AuthSecret))
             {
                 throw new Exception("Auth infos missing. Open Authorization URL first.");
@@ -591,6 +599,8 @@ namespace ShareX.UploadersLib
             {
                 return OAuthManager.ParseAccessTokenResponse(response, authInfo);
             }
+
+            */
 
             return null;
         }

--- a/ShareX/ApplicationConfig.cs
+++ b/ShareX/ApplicationConfig.cs
@@ -243,7 +243,7 @@ namespace ShareX
         public bool PNGStripColorSpaceInformation { get; set; }
 
         [Category("Upload"), DefaultValue(false), Description("Can be used to disable uploading application wide.")]
-        public bool DisableUpload { get; set; }
+        public bool DisableUpload => true;
 
         [Category("Upload"), DefaultValue(false), Description("Accept invalid SSL certificates when uploading.")]
         public bool AcceptInvalidSSLCertificates { get; set; }

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -1950,21 +1950,7 @@ namespace ShareX
 
         public static bool IsUploadAllowed()
         {
-            if (SystemOptions.DisableUpload)
-            {
-                MessageBox.Show(Resources.YourSystemAdminDisabledTheUploadFeature, "ShareX", MessageBoxButtons.OK, MessageBoxIcon.Information);
-
-                return false;
-            }
-
-            if (Program.Settings.DisableUpload)
-            {
-                MessageBox.Show(Resources.ThisFeatureWillNotWorkWhenDisableUploadOptionIsEnabled, "ShareX", MessageBoxButtons.OK, MessageBoxIcon.Information);
-
-                return false;
-            }
-
-            return true;
+            return false;
         }
     }
 }


### PR DESCRIPTION
Users can't set DisableUpload to false anymore. 
Also commented out a few extra methods inside the Uploader.cs.

![DisableUploadsAlwaysTrue](https://user-images.githubusercontent.com/3769981/163252307-5db5186b-434b-4ae6-88aa-7e508d7aaa69.gif)